### PR TITLE
Added yt-search as a dependency to fix npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "immutability-helper": "^3.1.1",
     "mysql": "^2.18.1",
     "rootpath": "^0.1.2",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "yt-search": "^2.3.2"
   }
 }


### PR DESCRIPTION
This small 1 line change was needed to fix npm start after a developer first pulls down the project.