### PR TITLE
Initial move queue button & function

### DIFF
--- a/frontend/src/components/QueueSection/QueueCard/QueueCard.js
+++ b/frontend/src/components/QueueSection/QueueCard/QueueCard.js
@@ -15,11 +15,15 @@ import {
 import { formatVideoTitle } from "../../../functions";
 import ClearIcon from "@material-ui/icons/Clear";
 
+import ArrowLeftIcon from '@material-ui/icons/ArrowLeft';
+import ArrowRightIcon from '@material-ui/icons/ArrowRight';
+
+
 const useStyles = makeStyles((theme) => ({
   card: {
     cursor: "move",
     display: "inline-block",
-    width: "100px",
+    width: "150px",
     position: "relative",
     marginLeft: "41.5px",
     marginTop: "25px",
@@ -32,6 +36,23 @@ const useStyles = makeStyles((theme) => ({
     position: "absolute",
     top: theme.spacing(1),
     right: theme.spacing(0.5),
+  },
+  buttonUp: {
+    visibility: "hidden",
+    position: "absolute",
+    bottom: theme.spacing(0),
+    backgroundColor: "rgba(60,60,60,0.9)",
+  },
+  buttonDown: {
+    visibility: "hidden",
+    position: "absolute",
+    bottom: theme.spacing(0),
+    right: theme.spacing(0),
+    backgroundColor: "rgba(60,60,60,0.9)",
+  },
+  cardButton: {
+    width: "40px",
+    height: "30px",
   },
 }));
 
@@ -46,6 +67,7 @@ export default function ImgMediaCard({
   setQueue,
   thumbnail,
   title,
+  moveCardButton,
 }) {
   const classes = useStyles();
 
@@ -57,6 +79,17 @@ export default function ImgMediaCard({
         return item.qid !== qid;
       })
     );
+  };
+
+  const moveQueueItem = (cardIndex, direction) => {
+    // Determine the direction of which to move the queue within the queue list's range
+    if(direction == "up" && cardIndex > 0){
+      moveCardButton(cardIndex, -1);
+    }
+    else if(direction == "down" && cardIndex < queue.length){
+      moveCardButton(cardIndex, 1);
+    }
+    // Function will not do anything if the current card will be out of bounds
   };
 
   const [, drop] = useDrop({
@@ -131,6 +164,34 @@ export default function ImgMediaCard({
           </Typography>
         </CardContent>
       </CardActionArea>
+
+      <Box className={classes.buttonUp} backgroundColor="primary">
+      <Tooltip title="move up in queue">
+          <IconButton value="up" className={classes.cardButton}
+              edge="start"
+              color="secondary"
+              onClick={() => moveQueueItem(index, "up")}
+              size="small"
+              style={{background: "none" }}
+            >
+            <ArrowLeftIcon />
+          </IconButton>
+      </Tooltip>
+      </Box>
+      <Box className={classes.buttonDown}>
+      <Tooltip title="move down in queue">
+          <IconButton className={classes.cardButton}
+              edge="start"
+              color="secondary"
+              onClick={() => moveQueueItem(index, "down")}
+              size="small"
+              style={{background: "none"}}
+            >
+            <ArrowRightIcon />
+          </IconButton>
+      </Tooltip>
+      </Box>
+
 
       <Box className={classes.overlay}>
         <Tooltip title="remove from queue">

--- a/frontend/src/components/QueueSection/QueueSection.js
+++ b/frontend/src/components/QueueSection/QueueSection.js
@@ -56,7 +56,20 @@ function QueueSection({
     [queue]
   );
 
+  const moveCardButton = (cardIndex, changeIndex) => {
+    const currCard = queue[cardIndex];
+    setQueue(
+      update(queue, {
+        $splice: [
+          [cardIndex, 1],
+          [(cardIndex + (changeIndex)), 0, currCard],
+        ],
+      })
+    );
+  }
+
   const editingQueueName = tempQueueName === queueName;
+
 
   return (
     <>
@@ -109,6 +122,7 @@ function QueueSection({
                 nowPlaying={nowPlaying}
                 onClickImage={handleClickQueueItem}
                 moveCard={moveCard}
+                moveCardButton={moveCardButton}
               />
             ))}
           </DndProvider>


### PR DESCRIPTION
This pull request could close issue #64.
Created two IconButton components to allow the users to move the hovering queue card up or down the queue.
Minor Changes:
- increased classes.card width from 100px to 150px to fit the move buttons

Before:
![image](https://user-images.githubusercontent.com/71283454/97791997-f397bf80-1bae-11eb-868b-8e6ee988d2c1.png)
After:
![image](https://user-images.githubusercontent.com/71283454/97792012-1a55f600-1baf-11eb-831b-80cca8601e4f.png)

Thank you for the opportunity.
